### PR TITLE
Replace encoding with compression. Bump version

### DIFF
--- a/lib/zjson-bin.js
+++ b/lib/zjson-bin.js
@@ -9,7 +9,6 @@
  * - Log is not efficient to allow
  * - the zjon format should carry some flags (is it compressed and needs decompression)
  * - dictionary index is 32based... not optimum where there is more than 32 field names in the object.
- * - bjson could be implemented in msgpack-lite. other gzip-based libs were not efficient compression as it would not optimize the javascript obj.
  *
  * DEVELOPMENT
  * When enhancing this lib, recommendation
@@ -27,7 +26,7 @@
   function() {
     registerLib(this, factory);
 
-    function factory(_, msgpack, logger) {
+    function factory(_, pako, logger) {
       'strict mode';
 
       const zjsonbin = {
@@ -67,35 +66,15 @@
         }
         const start = Date.now();
 
-        const cJson = pack(obj);
-        const serializedObj = msgpack.encode(cJson);
-        const string = abs2str(serializedObj);
+        const serializedObj = pako.deflate(JSON.stringify(obj), { to: 'string' });
 
         if (zjsonbin.debug === 2) {
-          const compression = Math.round(Number(100 * string.length / objLength) * 10) / 10;
-          logger.debug('Serialize object to size ' + getSizeFormat(string.length) + ', compressed to ' + compression + '% in ' + getTimeFormat(Date.now() - start));
+          const compression = Math.round(Number(100 * serializedObj.length / objLength) * 10) / 10;
+          logger.debug('Serialize object to size ' + getSizeFormat(serializedObj.length) + ', compressed to ' + compression + '% in ' + getTimeFormat(Date.now() - start));
         } else if (zjsonbin.debug) {
-          logger.debug('Serialize object to size ' + getSizeFormat(string.length) + ' in ' + getTimeFormat(Date.now() - start));
+          logger.debug('Serialize object to size ' + getSizeFormat(serializedObj.length) + ' in ' + getTimeFormat(Date.now() - start));
         }
-        return string;
-
-        // const jsonText = JSON.stringify(obj);
-        // const jsonT = Date.now();
-
-        // const jsonParse = jsonify(obj);
-        // const jsonP = Date.now();
-
-        // const packed = msgpack.encode(jsonParse);
-        // //jsonpack.pack(jsonParse);
-        // const packedT = Date.now();
-        // const compression = Math.round(Number(100 * packed.length / jsonText.length) * 10) / 10;
-
-        // debug && logger.debug('Serialize object to size %b, compressed to %b - jtext %b - jparse %b - packed %b',
-        //     getSizeFormat(packed.length), compression + '%',
-        //     getTimeFormat(jsonT - start),
-        //     getTimeFormat(jsonP - jsonT),
-        //     getTimeFormat(packedT - jsonP));
-        // return packed;
+        return serializedObj;
       }
 
       /**
@@ -104,17 +83,17 @@
        * @param {String} stringData
        * @return {Object} obj
        */
-      function deserialize(stringData) {
-        if (zjsonbin.disabled || _.isEmpty(stringData)) {
+      function deserialize(binaryString) {
+        if (zjsonbin.disabled || _.isEmpty(binaryString)) {
           return null;
         }
 
         const start = Date.now();
-        const serializedObj = str2ab(stringData);
-        const compactJson = msgpack.decode(serializedObj);
-        const obj = unpack(compactJson);
+        const compactJson = pako.inflate(binaryString, { to: 'string' });
+
+        const obj = JSON.parse(compactJson);
         zjsonbin.debug && logger.debug('Deserialized object of size ' +
-          getSizeFormat(stringData.length) + ' in ' + getTimeFormat(Date.now() - start));
+        getSizeFormat(binaryString.length) + ' in ' + getTimeFormat(Date.now() - start));
 
         return obj;
       }
@@ -125,138 +104,6 @@
 
       function getTimeFormat(lap) {
         return lap >= 1000 ? Math.round((lap) / 100) / 10 + 's' : lap + 'ms';
-      }
-
-      /**
-       * take an object,
-       * jsonify it and factor its property names (dictionary use) to reduce its size
-       * @param {*} obj
-       * @returns {Object} optimized json object
-       */
-      function pack(obj) {
-        const dictionaryNames = {},
-          dictionary = [];
-        let n = 0;
-        const r = _.cloneDeepWith(obj, processProperty);
-        return [dictionary, r];
-
-        function processProperty(objProperty) {
-          if (objProperty && objProperty.toJSON) {
-            objProperty = objProperty.toJSON();
-          }
-          if (_.isArray(objProperty)) {
-            return _.map(objProperty, function(item) {
-              if (_.isNil(objProperty)) {
-                return null;
-              }
-              return _.cloneDeepWith(item, processProperty);
-            });
-          }
-          if (_.isObject(objProperty)) {
-            // Data coming in can use new Number(42) instead of 42
-            if (_.isNumber(objProperty)) {
-              return Number(objProperty);
-            }
-            // Data coming in can use new String('test') instead of 'test'
-            if (_.isString(objProperty)) {
-              return String(objProperty);
-            }
-
-            let property, d;
-            const newObj = {};
-            for (property in objProperty) {
-              if (!_.isNil(objProperty[property]) && !_.isFunction(objProperty[property])) {
-                d = dictionaryNames[property];
-                if (_.isNil(d)) {
-                  d = (n++).toString(36);
-                  dictionaryNames[property] = d;
-                  dictionary.push(property);
-                }
-
-                newObj[d] = _.cloneDeepWith(objProperty[property], processProperty);
-              }
-            }
-            return newObj;
-          }
-          return objProperty;
-        }
-      }
-
-      /**
-       * take a packed(optimized) json object and unpack to recover its original form.
-       *
-       * @param {Object} packedObj
-       */
-      function unpack(packedObj) {
-        const dictionary = packedObj[0];
-        const r = _.cloneDeepWith(packedObj[1], processProperty);
-        return r;
-
-        function processProperty(objProperty) {
-          if (_.isArray(objProperty)) {
-            return _.map(objProperty, function(item) {
-              if (_.isNil(objProperty)) {
-                return null;
-              }
-              return _.cloneDeepWith(item, processProperty);
-            });
-          }
-          if (_.isObject(objProperty)) {
-            // console.log(objProperty.constructor.name);
-            const newObj = {};
-            for (let property in objProperty) {
-              if (!_.isNil(objProperty[property]) && !_.isFunction(objProperty[property])) {
-                let d = dictionary[parseInt(property, 36)];
-                newObj[d] = _.cloneDeepWith(objProperty[property], processProperty);
-              }
-            }
-            return newObj;
-          }
-          return objProperty;
-        }
-      }
-
-      /**
-       * Convert a string to a buffer
-       *
-       * note that this is only correct if your buffer only contains non-multibyte ASCII characters:
-       *
-       * @param {String} str
-       *
-       * @returns {Uint8Array}
-       */
-      function str2ab(str) {
-        let buf = new ArrayBuffer(str.length); // 2 bytes for each char
-        let bufView = new Uint8Array(buf);
-        for (let i = 0, strLen = str.length; i < strLen; i++) {
-          bufView[i] = str.charCodeAt(i);
-        }
-        return bufView;
-      }
-
-      /**
-       * Convert a buffer to a string
-       *
-       * and prevent Maximum call stack size exceeded
-       *
-       * https://stackoverflow.com/questions/12710001/how-to-convert-uint8-array-to-base64-encoded-string/12713326#12713326
-       *
-       * note that this is only correct if your buffer only contains non-multibyte ASCII characters:
-       * @param {Uint8Array} u8a
-       *
-       * @return {String}
-       */
-      function abs2str(u8a) {
-        let CHUNK_SZ = 0x8000;
-        if (u8a.length < CHUNK_SZ) {
-          return String.fromCharCode.apply(null, u8a);
-        }
-
-        let c = [];
-        for (let i = 0; i < u8a.length; i += CHUNK_SZ) {
-          c.push(String.fromCharCode.apply(null, u8a.subarray(i, i + CHUNK_SZ)));
-        }
-        return c.join("");
       }
 
       /**
@@ -482,17 +329,17 @@
         // register for node
         logger = require('zimit-zlog').getLogger('zjsonbin');
         logger.setLevel('all');
-        factory(require("lodash"), require("msgpack-lite"), logger);
+        factory(require("lodash"), require("pako"), logger);
       } else if (typeof define === "function" && define.amd) {
         // not tested.
         logger = { debug: console.debug };
-        define(["_", "msgpack-lite"], logger, function(lodash, msgpack) {
-          factory(lodash, msgpack, logger);
+        define(["_", "pako"], logger, function(lodash, pako) {
+          factory(lodash, pako, logger);
         });
       } else {
         // register lib for browser if dependency are loaded.
         logger = { debug: console.debug };
-        factory(global._, global.msgpack, logger);
+        factory(global._, global.pako, logger);
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "zjsonbin",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1751,11 +1751,6 @@
         "es5-ext": "~0.10.14"
       }
     },
-    "event-lite": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/event-lite/-/event-lite-0.1.1.tgz",
-      "integrity": "sha1-R88IqNN9C2lM23s7F7UfqsZXYIY="
-    },
     "eventemitter3": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
@@ -2228,7 +2223,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.1.1",
@@ -2279,7 +2275,8 @@
         "balanced-match": {
           "version": "0.4.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "bcrypt-pbkdf": {
           "version": "1.0.1",
@@ -2294,6 +2291,7 @@
           "version": "0.0.9",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "inherits": "~2.0.0"
           }
@@ -2302,6 +2300,7 @@
           "version": "2.10.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "hoek": "2.x.x"
           }
@@ -2310,6 +2309,7 @@
           "version": "1.1.7",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^0.4.1",
             "concat-map": "0.0.1"
@@ -2318,7 +2318,8 @@
         "buffer-shims": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "caseless": {
           "version": "0.12.0",
@@ -2335,12 +2336,14 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "combined-stream": {
           "version": "1.0.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "delayed-stream": "~1.0.0"
           }
@@ -2348,22 +2351,26 @@
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "cryptiles": {
           "version": "2.0.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "boom": "2.x.x"
           }
@@ -2403,7 +2410,8 @@
         "delayed-stream": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "delegates": {
           "version": "1.0.0",
@@ -2435,7 +2443,8 @@
         "extsprintf": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "forever-agent": {
           "version": "0.6.1",
@@ -2457,12 +2466,14 @@
         "fs.realpath": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "fstream": {
           "version": "1.0.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "inherits": "~2.0.0",
@@ -2518,6 +2529,7 @@
           "version": "7.1.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -2530,7 +2542,8 @@
         "graceful-fs": {
           "version": "4.1.11",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "har-schema": {
           "version": "1.0.5",
@@ -2558,6 +2571,7 @@
           "version": "3.1.3",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "boom": "2.x.x",
             "cryptiles": "2.x.x",
@@ -2568,7 +2582,8 @@
         "hoek": {
           "version": "2.16.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "http-signature": {
           "version": "1.1.1",
@@ -2585,6 +2600,7 @@
           "version": "1.0.6",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "once": "^1.3.0",
             "wrappy": "1"
@@ -2593,7 +2609,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.4",
@@ -2605,6 +2622,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2618,7 +2636,8 @@
         "isarray": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "isstream": {
           "version": "0.1.2",
@@ -2691,12 +2710,14 @@
         "mime-db": {
           "version": "1.27.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "mime-types": {
           "version": "2.1.15",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "mime-db": "~1.27.0"
           }
@@ -2705,6 +2726,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2712,12 +2734,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2772,7 +2796,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "oauth-sign": {
           "version": "0.8.2",
@@ -2790,6 +2815,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2819,7 +2845,8 @@
         "path-is-absolute": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "performance-now": {
           "version": "0.2.0",
@@ -2830,7 +2857,8 @@
         "process-nextick-args": {
           "version": "1.0.7",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "punycode": {
           "version": "1.4.1",
@@ -2868,6 +2896,7 @@
           "version": "2.2.9",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "buffer-shims": "~1.0.0",
             "core-util-is": "~1.0.0",
@@ -2912,6 +2941,7 @@
           "version": "2.6.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "glob": "^7.0.5"
           }
@@ -2919,7 +2949,8 @@
         "safe-buffer": {
           "version": "5.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "semver": {
           "version": "5.3.0",
@@ -2943,6 +2974,7 @@
           "version": "1.0.9",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "hoek": "2.x.x"
           }
@@ -2976,6 +3008,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2986,6 +3019,7 @@
           "version": "1.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.0.1"
           }
@@ -3000,6 +3034,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3014,6 +3049,7 @@
           "version": "2.2.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "block-stream": "*",
             "fstream": "^1.0.2",
@@ -3069,7 +3105,8 @@
         "util-deprecate": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "uuid": {
           "version": "3.0.1",
@@ -3098,7 +3135,8 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -4309,11 +4347,6 @@
       "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
       "dev": true
     },
-    "ieee754": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
-      "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
-    },
     "ignore": {
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
@@ -4389,11 +4422,6 @@
         "strip-ansi": "^3.0.0",
         "through": "^2.3.6"
       }
-    },
-    "int64-buffer": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/int64-buffer/-/int64-buffer-0.1.9.tgz",
-      "integrity": "sha1-ngOdoEOyT3ixlrKD4EZT716ZD2E="
     },
     "interpret": {
       "version": "1.1.0",
@@ -4644,7 +4672,8 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
     },
     "isbinaryfile": {
       "version": "3.0.2",
@@ -5674,17 +5703,6 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
-    "msgpack-lite": {
-      "version": "0.1.26",
-      "resolved": "https://registry.npmjs.org/msgpack-lite/-/msgpack-lite-0.1.26.tgz",
-      "integrity": "sha1-3TxQsm8FnyXn7e42REGDWOKprYk=",
-      "requires": {
-        "event-lite": "^0.1.1",
-        "ieee754": "^1.1.8",
-        "int64-buffer": "^0.1.9",
-        "isarray": "^1.0.0"
-      }
-    },
     "multipipe": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
@@ -5989,6 +6007,11 @@
         "mkdirp": "^0.5.1",
         "object-assign": "^4.1.0"
       }
+    },
+    "pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
     },
     "parse-filepath": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zjsonbin",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "Json serialization/deserialization Tool Set",
   "main": "lib/zjson-bin.js",
   "keywords": [
@@ -21,7 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "lodash": "^4.0.0",
-    "msgpack-lite": "^0.1.26",
+    "pako": "^1.0.11",
     "promise": "^7.1.1",
     "zimit-zlog": "1.0.3"
   },

--- a/specs/zjson-bin.spec.js
+++ b/specs/zjson-bin.spec.js
@@ -68,9 +68,8 @@ describe('zjsonbin', () => {
           42,
           'item 2'
         ]
-      }
-      // Eliminated, it has no value
-      // property3: null,
+      },
+      property3: null,
     });
   });
 


### PR DESCRIPTION
Added compression 
Reduce overhead with transforming To/From ArrayBuffer
Reduced packing overhead that used multiple deep clones
Default zlib compression is 6

Performance metrics:
Before:
```
2020-03-20 06:20:02 EDT DEBUG zjsonbin             - Serialize object to size 35b in 1ms
2020-03-20 06:20:02 EDT DEBUG zjsonbin             - Deserialized object of size 35b in 1ms
2020-03-20 06:20:02 EDT DEBUG zjsonbin             - Serialize object to size 119b in 1ms
2020-03-20 06:20:02 EDT DEBUG zjsonbin             - Deserialized object of size 119b in 1ms
2020-03-20 06:20:02 EDT DEBUG zjsonbin             - Serialize object to size 915.53Kb in 243ms
2020-03-20 06:20:02 EDT DEBUG zjsonbin             - Deserialized object of size 915.53Kb in 187ms
```

After:
```
2020-03-20 06:08:27 EDT DEBUG zjsonbin             - Serialize object to size 38b in 7ms
2020-03-20 06:08:27 EDT DEBUG zjsonbin             - Deserialized object of size 38b in 5ms
2020-03-20 06:08:27 EDT DEBUG zjsonbin             - Serialize object to size 130b in 1ms
2020-03-20 06:08:27 EDT DEBUG zjsonbin             - Deserialized object of size 130b in 0ms
2020-03-20 06:08:27 EDT DEBUG zjsonbin             - Serialize object to size 295.94Kb in 209ms
2020-03-20 06:08:27 EDT DEBUG zjsonbin             - Deserialized object of size 295.94Kb in 89ms
```

Low size files serialized better because on packing stage it removed keys with empty values that is not really affecting on overall size, but we can expect at least 3x boost on 900kb files. And looks like compressor performance is better on larger files and it would be event better after 1-2 thousands of compressions function runs, because V8 engine will optimize frequently executed functions.